### PR TITLE
fix: check for nullptr in SetMainWindowText

### DIFF
--- a/DxWindowLinux.cpp
+++ b/DxWindowLinux.cpp
@@ -19,7 +19,7 @@ extern int NS_GetWindowSize(int *Width, int *Height){
 extern int NS_SetMainWindowText(const TCHAR *WindowText){
     Display* d = GLINUX.Device.Screen.XDisplay;
     Window w = GLINUX.Device.Screen.XWindow;
-    // Original DxLib difference: the value isn't applied if the window doesn't exist yet.
+    // [本家非互換]ウィンドウが存在していない場合は反映されない
     if((!d)||(!w)){
         return -1;
     }

--- a/DxWindowLinux.cpp
+++ b/DxWindowLinux.cpp
@@ -19,6 +19,10 @@ extern int NS_GetWindowSize(int *Width, int *Height){
 extern int NS_SetMainWindowText(const TCHAR *WindowText){
     Display* d = GLINUX.Device.Screen.XDisplay;
     Window w = GLINUX.Device.Screen.XWindow;
+    // Original DxLib difference: the value isn't applied if the window doesn't exist yet.
+    if((!d)||(!w)){
+        return -1;
+    }
     Xutf8SetWMProperties(d, w, WindowText, NULL, NULL, 0, NULL, NULL, NULL);
     return 0;
 }

--- a/samples/sample09_window.cpp
+++ b/samples/sample09_window.cpp
@@ -10,6 +10,7 @@ int main(){
     SetWindowMaximizeButtonBehavior(1);
 #endif
     SetGraphMode(800, 600, 0, 0);
+    SetMainWindowText("fail");
     if(DxLib_Init() == -1){
         return -1;
     }

--- a/samples/sample09_window.cpp
+++ b/samples/sample09_window.cpp
@@ -10,7 +10,6 @@ int main(){
     SetWindowMaximizeButtonBehavior(1);
 #endif
     SetGraphMode(800, 600, 0, 0);
-    SetMainWindowText("fail");
     if(DxLib_Init() == -1){
         return -1;
     }


### PR DESCRIPTION
Hi! Thank you for your library. A little difference with the original DxLib I've stumbled upon while porting an app to Linux. SetMainWindowText() crashed for me when run before DxLib_Init(). A little nullptr check fixes the crash, although the behaviour is still a bit different: original DxLib doesn't discard the value if the window doesn't exist yet.